### PR TITLE
Refactor: Open extension in a new tab instead of popup

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -8,7 +8,8 @@ chrome.commands.onCommand.addListener((command) => {
 
 // Listen for extension icon click
 chrome.action.onClicked.addListener(() => {
-  saveCurrentTab();
+  const APP_PAGE = chrome.runtime.getURL("index.html");
+  chrome.tabs.create({ url: APP_PAGE });
 });
 
 // Function to save the current tab

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,14 +5,13 @@
   "version": "1.0.0",
   "description": "myTABs helps you organize your browser tabs, notes, and todos in one place",
   "action": {
-    "default_popup": "index.html",
     "default_icon": {
       "16": "icon16.png",
       "48": "icon48.png",
       "128": "icon128.png"
     }
   },
-  "permissions": ["storage", "tabs", "bookmarks", "activeTab"],
+  "permissions": ["storage", "tabs", "bookmarks", "activeTab", "windows"],
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,8 +24,17 @@ export default defineConfig(({ mode }) => ({
   build: {
     outDir: 'dist',
     rollupOptions: {
+      input: {
+        main: 'index.html',
+        background: 'public/background.js'
+      },
       output: {
-        entryFileNames: 'assets/[name].js',
+        entryFileNames: (chunkInfo) => {
+          if (chunkInfo.name === 'background') {
+            return 'background.js'; // Output background.js to root
+          }
+          return 'assets/[name].js'; // Other JS entries to assets folder
+        },
         chunkFileNames: 'assets/[name].js',
         assetFileNames: 'assets/[name].[ext]'
       }


### PR DESCRIPTION
This removes the `default_popup` from `manifest.json` and updates the `chrome.action.onClicked` listener in `background.js` to open the extension's `index.html` in a new browser tab.

This change provides you with a full-page experience instead of a constrained popup window.

The `manifest.json` permissions were updated to include "windows" (though "tabs" is the primary permission used for this specific change). The Vite build configuration (`vite.config.ts`) was also adjusted to ensure `index.html` and `background.js` are correctly output to the root of the `dist` directory.