### PR TITLE
Fix toast listener cleanup

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -180,7 +180,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix cleanup of toast listeners to prevent memory leak in `use-toast`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684085daac508330b9387528e6b9e2ea