### PR TITLE
Add Jest test for useIsMobile hook

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(ts|tsx)$': '<rootDir>/jest.esbuild-transform.cjs',
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/jest.esbuild-transform.cjs
+++ b/jest.esbuild-transform.cjs
@@ -1,0 +1,17 @@
+const { transformSync } = require('esbuild');
+
+module.exports = {
+  process(src, filename) {
+    const loader = filename.endsWith('.tsx')
+      ? 'tsx'
+      : filename.endsWith('.ts')
+      ? 'ts'
+      : 'js';
+    const { code } = transformSync(src, {
+      loader,
+      format: 'cjs',
+      sourcemap: 'inline',
+    });
+    return { code };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/__tests__/use-mobile.test.tsx
+++ b/src/__tests__/use-mobile.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { act } from 'react-dom/test-utils'
+import { useIsMobile } from '../hooks/use-mobile'
+
+function renderHook() {
+  let result: boolean | undefined
+  function Test() {
+    result = useIsMobile()
+    return null
+  }
+  const container = document.createElement('div')
+  act(() => {
+    ReactDOM.render(<Test />, container)
+  })
+  // allow useEffect to run
+  act(() => {})
+  return result
+}
+
+describe('useIsMobile', () => {
+  const originalMatchMedia = window.matchMedia
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+  })
+
+  it('returns true on mobile widths', () => {
+    window.innerWidth = 500
+    window.matchMedia = jest.fn().mockReturnValue({
+      matches: true,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })
+
+    const value = renderHook()
+    expect(value).toBe(true)
+  })
+
+  it('returns false on desktop widths', () => {
+    window.innerWidth = 1024
+    window.matchMedia = jest.fn().mockReturnValue({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })
+
+    const value = renderHook()
+    expect(value).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add Jest config using esbuild transformer
- add unit test for `useIsMobile` hook mocking `matchMedia`
- provide npm `test` script in package.json

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6840898a02ec8330a02acc672919b719