### PR TITLE
Introduce Workspace context provider

### DIFF
--- a/src/components/CreateItemDialog.tsx
+++ b/src/components/CreateItemDialog.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Group, ItemType, Tab, Note, TodoList } from "@/hooks/useWorkspaceData";
+import { Group, ItemType, Tab, Note, TodoList } from "@/hooks/useWorkspace";
 import { Link, ListChecks, StickyNote } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 

--- a/src/components/ImportTabsButton.tsx
+++ b/src/components/ImportTabsButton.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Download } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import BrowserService from "@/services/BrowserService";
-import useWorkspaceData from "@/hooks/useWorkspaceData";
+import { useWorkspace } from "@/hooks/useWorkspace";
 
 interface ImportTabsButtonProps {
   selectedGroup: string;
@@ -12,7 +12,7 @@ interface ImportTabsButtonProps {
 
 const ImportTabsButton: React.FC<ImportTabsButtonProps> = ({ selectedGroup }) => {
   const { toast } = useToast();
-  const { addItem } = useWorkspaceData();
+  const { addItem } = useWorkspace();
 
   const handleImportTabs = async () => {
     try {

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Note } from "@/hooks/useWorkspaceData";
+import { Note } from "@/hooks/useWorkspace";
 import { Pencil, Save, X } from "lucide-react";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";

--- a/src/components/SaveCurrentTabButton.tsx
+++ b/src/components/SaveCurrentTabButton.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Save, List } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import BrowserService from "@/services/BrowserService";
-import useWorkspaceData from "@/hooks/useWorkspaceData";
+import { useWorkspace } from "@/hooks/useWorkspace";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,7 +18,7 @@ interface SaveCurrentTabButtonProps {
 
 const SaveCurrentTabButton: React.FC<SaveCurrentTabButtonProps> = ({ selectedGroup }) => {
   const { toast } = useToast();
-  const { data, addItem } = useWorkspaceData();
+  const { data, addItem } = useWorkspace();
   const [isLoading, setIsLoading] = useState(false);
   const [openTabs, setOpenTabs] = useState<Array<{
     id: number;

--- a/src/components/TabCard.tsx
+++ b/src/components/TabCard.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { ExternalLink, X, Bookmark, BookmarkCheck } from "lucide-react";
-import { Tab } from "@/hooks/useWorkspaceData";
+import { Tab } from "@/hooks/useWorkspace";
 import { useToast } from "@/hooks/use-toast";
 
 interface TabCardProps {

--- a/src/components/TabGroup.tsx
+++ b/src/components/TabGroup.tsx
@@ -4,9 +4,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import TabCard from "./TabCard";
 import NoteCard from "./NoteCard";
 import { Badge } from "@/components/ui/badge";
-import { Tab, Note, TodoList, Group } from "@/hooks/useWorkspaceData";
+import { useWorkspace, Tab, Note, TodoList, Group } from "@/hooks/useWorkspace";
 import TodoListComponent from "./TodoListComponent";
-import useWorkspaceData from "@/hooks/useWorkspaceData";
 
 interface TabGroupProps {
   group: Group;
@@ -32,7 +31,7 @@ const TabGroup: React.FC<TabGroupProps> = ({
   onDeleteTodoList
 }) => {
   const groupColor = group.color || "#4f46e5";
-  const { toggleBookmark } = useWorkspaceData();
+  const { toggleBookmark } = useWorkspace();
   
   return (
     <div className="flex flex-col gap-4 kanban-column">

--- a/src/components/TodoListComponent.tsx
+++ b/src/components/TodoListComponent.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-import { TodoItem, TodoList } from "@/hooks/useWorkspaceData";
+import { TodoItem, TodoList } from "@/hooks/useWorkspace";
 import { Button } from "@/components/ui/button";
 import { Pencil, Plus, Save, Trash2, X } from "lucide-react";
 

--- a/src/components/WorkspaceBoard.tsx
+++ b/src/components/WorkspaceBoard.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import TabGroup from "./TabGroup";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
-import useWorkspaceData, { Group, Note, Tab, TodoList } from "@/hooks/useWorkspaceData";
+import { useWorkspace, Group, Note, Tab, TodoList } from "@/hooks/useWorkspace";
 
 interface WorkspaceBoardProps {
   onCreateGroup: () => void;
@@ -11,11 +11,11 @@ interface WorkspaceBoardProps {
 }
 
 const WorkspaceBoard: React.FC<WorkspaceBoardProps> = ({ onCreateGroup, groups = [] }) => {
-  const { 
-    data, 
-    deleteItem, 
-    updateItem 
-  } = useWorkspaceData();
+  const {
+    data,
+    deleteItem,
+    updateItem
+  } = useWorkspace();
   
   // Use the groups prop if provided, otherwise fall back to data.groups
   const displayGroups = groups.length > 0 ? groups : data.groups;

--- a/src/hooks/useWorkspace.tsx
+++ b/src/hooks/useWorkspace.tsx
@@ -1,0 +1,45 @@
+import { ReactNode, createContext, useContext } from 'react';
+import useWorkspaceData, {
+  WorkspaceData,
+  Group,
+  Tab,
+  Note,
+  TodoList,
+  TodoItem,
+  ItemType
+} from './useWorkspaceData';
+
+interface WorkspaceContextType {
+  data: WorkspaceData;
+  isLoading: boolean;
+  addItem: (type: ItemType, item: any) => Promise<void>;
+  updateItem: (type: ItemType, id: string, updates: Partial<Tab | Note | TodoList>) => Promise<void>;
+  deleteItem: (type: ItemType, id: string) => Promise<void>;
+  addGroup: (group: Group) => Promise<void>;
+  updateGroup: (id: string, updates: Partial<Group>) => Promise<void>;
+  deleteGroup: (id: string) => Promise<void>;
+  moveItem: (type: ItemType, id: string, newGroupId: string) => Promise<void>;
+  toggleBookmark: (tabId: string) => Promise<void>;
+  getBookmarkedTabs: () => Tab[];
+}
+
+const WorkspaceContext = createContext<WorkspaceContextType | undefined>(undefined);
+
+export const WorkspaceProvider = ({ children }: { children: ReactNode }) => {
+  const workspace = useWorkspaceData();
+  return (
+    <WorkspaceContext.Provider value={workspace}>
+      {children}
+    </WorkspaceContext.Provider>
+  );
+};
+
+export const useWorkspace = () => {
+  const context = useContext(WorkspaceContext);
+  if (context === undefined) {
+    throw new Error('useWorkspace must be used within a WorkspaceProvider');
+  }
+  return context;
+};
+
+export type { WorkspaceData, Group, Tab, Note, TodoList, TodoItem, ItemType };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client'
 import { HashRouter } from 'react-router-dom' // Ensure HashRouter is imported
 import { AuthProvider } from './hooks/useAuth'
+import { WorkspaceProvider } from './hooks/useWorkspace'
 import { Toaster } from '@/components/ui/toaster'
 import App from './App.tsx'
 import './index.css'
@@ -8,8 +9,10 @@ import './index.css'
 createRoot(document.getElementById("root")!).render(
   <HashRouter>
     <AuthProvider>
-      <Toaster />
-      <App />
+      <WorkspaceProvider>
+        <Toaster />
+        <App />
+      </WorkspaceProvider>
     </AuthProvider>
   </HashRouter>
 );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,7 +4,7 @@ import Header from "@/components/Header";
 import WorkspaceBoard from "@/components/WorkspaceBoard";
 import CreateItemDialog from "@/components/CreateItemDialog";
 import CreateGroupDialog from "@/components/CreateGroupDialog";
-import useWorkspaceData, { ItemType, Group, Tab } from "@/hooks/useWorkspaceData";
+import { useWorkspace, ItemType, Group, Tab } from "@/hooks/useWorkspace";
 import TabCard from "@/components/TabCard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BookmarkCheck, LogOut } from "lucide-react";
@@ -18,7 +18,7 @@ const Index: React.FC = () => {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isCreateGroupDialogOpen, setIsCreateGroupDialogOpen] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState("");
-  const { data, addItem, addGroup, deleteItem, toggleBookmark, getBookmarkedTabs, isLoading } = useWorkspaceData();
+  const { data, addItem, addGroup, deleteItem, toggleBookmark, getBookmarkedTabs, isLoading } = useWorkspace();
   const { signOut, user } = useAuth();
 
   // Set default selected group if available

--- a/src/services/BrowserService.ts
+++ b/src/services/BrowserService.ts
@@ -1,5 +1,5 @@
 
-import { Tab } from "@/hooks/useWorkspaceData";
+import { Tab } from "@/hooks/useWorkspace";
 
 interface ChromeTab {
   id: number;


### PR DESCRIPTION
## Summary
- create `useWorkspace` context and provider wrapping `useWorkspaceData`
- use `WorkspaceProvider` in `main.tsx`
- update pages and components to consume the new context
- re-export workspace types for consumers

## Testing
- `npm run build` *(fails: Cannot find package 'esbuild')*
- `npm run lint` *(fails: 16 errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684089714e008330b4c4f769dc0f1fd9