### PR TITLE
Add default window padding

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -86,7 +86,8 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    /* Provide padding on the edges so content doesn't touch the browser window */
+    @apply bg-background text-foreground px-4;
   }
 }
 


### PR DESCRIPTION
## Summary
- add padding on `body` so content doesn't touch window edges

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840bc6522b8833086886b301e0f42af